### PR TITLE
Bigger Pawn History

### DIFF
--- a/src/engine/history.h
+++ b/src/engine/history.h
@@ -10,7 +10,7 @@ using namespace Chess;
 namespace Engine {
 
 constexpr size_t CORR_SIZE = 16384;
-constexpr size_t PAWN_HIST_SIZE = 512;
+constexpr size_t PAWN_HIST_SIZE = 8192;
 
 int history_bonus(int depth);
 int history_malus(int depth);


### PR DESCRIPTION
Passed STC:
```
Elo   | 2.44 +- 1.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 36478 W: 9197 L: 8941 D: 18340
Penta | [120, 4287, 9208, 4465, 159]
```